### PR TITLE
change itests branch reference for samples to main

### DIFF
--- a/tests/integration/test_grafana_dashboards.py
+++ b/tests/integration/test_grafana_dashboards.py
@@ -61,7 +61,7 @@ async def test_rule_files_ingested_by_grafana(ops_test):
     await ops_test.model.applications[app_name].set_config(
         {
             "git_repo": "https://github.com/canonical/cos-configuration-k8s-operator.git",
-            "git_branch": "feature/fix_config_changed",
+            "git_branch": "main",
             "grafana_dashboards_path": "tests/samples/grafana_dashboards",
         }
     )

--- a/tests/integration/test_loki_push_api.py
+++ b/tests/integration/test_loki_push_api.py
@@ -54,7 +54,7 @@ async def test_rule_files_ingested_by_loki(ops_test):
         {
             # TODO confirm loki able to ingest folders with both alert and recording rules
             "git_repo": "https://github.com/canonical/cos-configuration-k8s-operator.git",
-            "git_branch": "feature/fix_config_changed",
+            "git_branch": "main",
             "loki_alert_rules_path": "tests/samples/loki_alert_rules",
         }
     )

--- a/tests/integration/test_prometheus_scrape.py
+++ b/tests/integration/test_prometheus_scrape.py
@@ -54,7 +54,7 @@ async def test_rule_files_ingested_by_prometheus(ops_test):
     await ops_test.model.applications[app_name].set_config(
         {
             "git_repo": "https://github.com/canonical/cos-configuration-k8s-operator.git",
-            "git_branch": "feature/fix_config_changed",
+            "git_branch": "main",
             "prometheus_alert_rules_path": "tests/samples/prometheus_alert_rules",
         }
     )


### PR DESCRIPTION
#10 introduced itests with sample files in a new location. Now that it is merge, the branch from which those samples are taken needs to be changed to `main`.