### PR TITLE
add sync-now action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,7 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+sync-now:
+  description: |
+    Sync relation data with files on disk. This action can be used to force an update instead of
+    waiting for git-sync wait-time to elapse and udpate-status hook to fire.

--- a/src/charm.py
+++ b/src/charm.py
@@ -230,7 +230,7 @@ class COSConfigCharm(CharmBase):
             for line in warnings.splitlines():
                 event.log(f"Warning: {line.strip()}")
 
-        event.set_results({"stdout": stdout})
+        event.set_results({"git-sync-stdout": stdout})
 
         # Do the same thing _update_status() is doing to make sure relation data is up-to-date
         self._common_exit_hook()

--- a/src/charm.py
+++ b/src/charm.py
@@ -210,7 +210,7 @@ class COSConfigCharm(CharmBase):
         event.log("Calling git-sync with --one-time...")
 
         try:
-            process = self.container.exec(self._command(one_time=True))
+            process = self.container.exec(self._git_sync_command_line(one_time=True))
         except APIError as e:
             event.fail(str(e))
             return
@@ -247,7 +247,7 @@ class COSConfigCharm(CharmBase):
         # but to keep unittest simpler, doing it from the charm container's mount point
         shutil.rmtree(self._repo_path, ignore_errors=True)
 
-    def _command(self, one_time=False) -> List[str]:
+    def _git_sync_command_line(self, one_time=False) -> List[str]:
         """Construct the command line for running git-sync.
 
         Args:
@@ -307,7 +307,7 @@ class COSConfigCharm(CharmBase):
                         "override": "replace",
                         "summary": f"{self._service_name} service",
                         "startup": "disabled",
-                        "command": " ".join(self._command()),
+                        "command": " ".join(self._git_sync_command_line()),
                     },
                 },
             }


### PR DESCRIPTION
This PR is for adding the `sync-now` action.
It is handy if an immediate update is needed from the repo into relation data.

Without this action, to force a sync, one would need to:
1. `juju config` to shorten the `git_wait` period
2. `juju model-config` to shorten the update-status interval
3. wait for relation data to update
4. restore the above to original values

Immediate use cases:
- integration tests: files show up on disk after the last hook fired - can use the action instead of the update-status hack
- similar for load tests: want to be able to run selenium/splinter knowing that the dashboards are already in place