### PR TITLE
Bump git-sync image used to 3.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,5 @@ well-defined state:
 # Charmhub resource revisions
 ## git-sync-image
 - Revision 1: `k8s.gcr.io/git-sync/git-sync:v3.4.0`
+- Revision 2: `k8s.gcr.io/git-sync/git-sync:v3.5.0`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Currently, supported relations are:
 
 ## OCI Images
 This charm can be used with the following image:
-- `k8s.gcr.io/git-sync/git-sync:v3.4.0`
+- `k8s.gcr.io/git-sync/git-sync:v3.5.0`
 
 
 [Prometheus operator]: https://charmhub.io/prometheus-k8s

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,7 +19,7 @@ resources:
   git-sync-image:
     type: oci-image
     description: OCI image for git-sync
-    upstream-source: k8s.gcr.io/git-sync/git-sync:v3.4.0
+    upstream-source: k8s.gcr.io/git-sync/git-sync:v3.5.0
 
 storage:
   content-from-git:

--- a/tox.ini
+++ b/tox.ini
@@ -97,10 +97,10 @@ commands =
 description = Run integration tests
 deps =
     #git+https://github.com/juju/python-libjuju.git
-    juju
+    juju==2.9.7
     pytest
     #git+https://github.com/charmed-kubernetes/pytest-operator.git
-    pytest-operator
+    pytest-operator==0.15.0
     aiohttp
     PyYAML
     prometheus_api_client


### PR DESCRIPTION
## Issue
The cos-config charm is currently using git-sync 3.4.0, which wasn't design to have repos changed between invocations, which is functionality that is needed for cos-config.


## Solution
The latest version of git-sync, 3.5.0, includes a [fix](https://github.com/kubernetes/git-sync/pull/499) for this. This PR updates docs accordingly. A [new resource](https://charmhub.io/cos-configuration-k8s/resources/git-sync-image) has already been pushed to charmhub.


## Context
Repo change between git-sync invocations is needed for subsequent invocations of `juju config git_repo=...`.


## Testing Instructions
`tox -e integration`


## Release Notes
Bump git-sync image version to 3.5.0.
