### PR TITLE
Add cloning depth config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ to [prometheus][Prometheus operator], [loki][Loki operator] or
 ```shell
 juju deploy cos-configuration-k8s \
   --config git_repo=https://path.to/repo \
-  --config git_reference=main \
+  --config git_branch=main \
+  --config git_depth=1 \
   --config prometheus_alert_rules_path=rules/prod/prometheus/
 
 juju relate cos-configuration-k8s prometheus-k8s

--- a/config.yaml
+++ b/config.yaml
@@ -11,8 +11,14 @@ options:
     default: master
   git_rev:
     type: string
-    description: the git revision (tag or hash) to check out
+    description: The git revision (tag or hash) to check out
     default: HEAD
+  git_depth:
+    type: int
+    description: >
+      Cloning depth, to truncate commit history to the specified number of commits.
+      Zero (default) means no truncating.
+    default: 0
   prometheus_alert_rules_path:
     type: string
     description: Relative path in repo to prometheus rules.

--- a/config.yaml
+++ b/config.yaml
@@ -17,8 +17,8 @@ options:
     type: int
     description: >
       Cloning depth, to truncate commit history to the specified number of commits.
-      Zero (default) means no truncating.
-    default: 0
+      Zero means no truncating.
+    default: 1
   prometheus_alert_rules_path:
     type: string
     description: Relative path in repo to prometheus rules.

--- a/src/charm.py
+++ b/src/charm.py
@@ -261,7 +261,7 @@ class COSConfigCharm(CharmBase):
         repo = cast(str, self.config.get("git_repo"))
         branch = cast(str, self.config.get("git_branch"))
         rev = cast(str, self.config.get("git_rev"))
-        depth = cast(str, self.config.get("git_depth"))
+        depth = cast(int, self.config.get("git_depth"))
 
         cmd = ["/git-sync"]
         cmd.extend(["--repo", repo])
@@ -269,8 +269,8 @@ class COSConfigCharm(CharmBase):
             cmd.extend(["--branch", branch])
         if rev:
             cmd.extend(["--rev", rev])
-        if depth and int(depth) > 0:
-            cmd.extend(["--depth", depth])
+        if depth and depth > 0:
+            cmd.extend(["--depth", str(depth)])
         cmd.extend(
             [
                 "--root",

--- a/src/charm.py
+++ b/src/charm.py
@@ -261,6 +261,7 @@ class COSConfigCharm(CharmBase):
         repo = cast(str, self.config.get("git_repo"))
         branch = cast(str, self.config.get("git_branch"))
         rev = cast(str, self.config.get("git_rev"))
+        depth = cast(str, self.config.get("git_depth"))
 
         cmd = ["/git-sync"]
         cmd.extend(["--repo", repo])
@@ -268,10 +269,10 @@ class COSConfigCharm(CharmBase):
             cmd.extend(["--branch", branch])
         if rev:
             cmd.extend(["--rev", rev])
+        if depth and int(depth) > 0:
+            cmd.extend(["--depth", depth])
         cmd.extend(
             [
-                "--depth",
-                "1",
                 "--root",
                 self._git_sync_mount_point_sidecar,
                 "--dest",


### PR DESCRIPTION
## Issue
Fixes #7.


## Solution
Add `depth` config option.


## Context
NTA.


## Testing Instructions
Deploy with various config options and look at git-sync kubectl logs.
Should have a correct `--depth` in the args.


## Release Notes
Add cloning depth config option
