### PR TITLE
Use Juju 3.1 for CI

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,7 +67,6 @@ topology = JujuTopology(
 ```
 
 """
-import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -76,7 +75,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class InvalidUUIDError(Exception):
@@ -120,11 +119,6 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
-        warnings.warn(
-            "observability_libs.v0.juju_topology is deprecated. Use `pip install cosl` instead",
-            category=DeprecationWarning,
-        )
-
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -32,7 +32,7 @@ async def test_kubectl_delete_pod(ops_test: OpsTest):
 
     cmd = [
         "sg",
-        "microk8s",
+        "snap_microk8s",
         "-c",
         " ".join(["microk8s.kubectl", "delete", "pod", "-n", ops_test.model_name, pod_name]),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju ~= 3.0.0
+    juju
     pytest
     pytest-operator
     aiohttp


### PR DESCRIPTION
## Issue
Use Juju 3.1 to get around the unit termination issue. Update libs.


