### PR TITLE
add ssh support for private repos

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,10 @@ options:
       Cloning depth, to truncate commit history to the specified number of commits.
       Zero means no truncating.
     default: 1
+  git_ssh_key:
+    type: string
+    description: >
+      An optional SSH key to use to clone the repository.
   prometheus_alert_rules_path:
     type: string
     description: Relative path in repo to prometheus rules.

--- a/src/charm.py
+++ b/src/charm.py
@@ -64,6 +64,7 @@ class COSConfigCharm(CharmBase):
     grafana_relation_name = "grafana-dashboards"
 
     _hash_placeholder = "failed to fetch hash"
+    _ssh_key_file_name = "cos-config-ssh-key"
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -291,6 +292,10 @@ class COSConfigCharm(CharmBase):
             ]
         )
 
+        if self.config.get("git_ssh_key"):
+            cmd.extend(["--ssh"])
+            cmd.extend(["--ssh-key-file", self._ssh_key_file_name])
+
         cmd.append("--one-time")
 
         return cmd
@@ -399,7 +404,15 @@ class COSConfigCharm(CharmBase):
 
     def _on_config_changed(self, _):
         """Event handler for ConfigChangedEvent."""
+        self._save_ssh_key()
         self._common_exit_hook()
+
+    def _save_ssh_key(self):
+        """Save SSH key from config to a file."""
+        ssh_key = self.config.get("git_ssh_key")
+        if ssh_key:
+            with open(self._ssh_key_file_name, "w") as output:
+                output.write(ssh_key)
 
     @property
     def _git_sync_version(self) -> Optional[str]:


### PR DESCRIPTION
## Issue
Closes #31


## Solution
Store the SSH key in the model as a configuration parameter, until we have Juju secrets.

TODO (documentation mainly):
- [ ] document well that setting `git_ssh_key` means using it
- [ ] explicitly state that the key will be saved in the model
- [ ] recommend using a key with very limited scope

## Testing Instructions
Try to sync a private repo and see if it succeeds!


## Release Notes
Add SSH support so that private repositories can be used with the charm.
