### PR TITLE
Tell LokiPushApiConsumer not to add topology labels to alerts

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -139,6 +139,7 @@ class COSConfigCharm(CharmBase):
             self.loki_relation_name,
             alert_rules_path=os.path.join(self._repo_path, self.config["loki_alert_rules_path"]),
             recursive=True,
+            skip_alert_topology_labeling=True,
         )
 
         self.grafana_dashboards_provider = GrafanaDashboardProvider(


### PR DESCRIPTION
## Issue
Use the new arg in `LokiPushApiConsumer` to bypass topology label injection. Closes #44 


## Release Notes
Use the new arg in `LokiPushApiConsumer` to bypass topology label injection. 