### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/src/charm.py
+++ b/src/charm.py
@@ -195,7 +195,7 @@ class COSConfigCharm(CharmBase):
         if not self.container.can_connect():
             event.fail("Container not ready")
             return
-        elif not self._configured:
+        if not self._configured:
             event.fail("Config options missing - use `juju config`")
             return
 
@@ -332,9 +332,8 @@ class COSConfigCharm(CharmBase):
 
         if match := re.match(".+/(.+)$", contents):
             return match.group(1)
-        else:
-            logger.debug("Unrecognized hash file format: %s", contents[:100])
-            return self._hash_placeholder
+        logger.debug("Unrecognized hash file format: %s", contents[:100])
+        return self._hash_placeholder
 
     def _stored_get(self, key: str) -> Optional[str]:
         if relation := self.model.get_relation(self._peer_relation_name):

--- a/tests/integration/loki_workload.py
+++ b/tests/integration/loki_workload.py
@@ -55,8 +55,8 @@ class LokiServer:
 
         if response.status_code == requests.codes.ok:
             return response.json()
-        else:
-            response.raise_for_status()
+        response.raise_for_status()
+        return None
 
     @property
     def version(self) -> str:

--- a/tests/unit/charm/test_reinitialize.py
+++ b/tests/unit/charm/test_reinitialize.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import hypothesis.strategies as st
 import ops
+from charm import COSConfigCharm
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LokiPushApiConsumer
 from charms.prometheus_k8s.v0.prometheus_scrape import PrometheusRulesProvider
@@ -17,8 +18,6 @@ from helpers import FakeProcessVersionCheck
 from hypothesis import given
 from ops.model import Container
 from ops.testing import Harness
-
-from charm import COSConfigCharm
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/charm/test_reinitialize.py
+++ b/tests/unit/charm/test_reinitialize.py
@@ -45,11 +45,11 @@ class TestReinitializeCalledOnce(unittest.TestCase):
 
         # GIVEN the current unit is a leader unit
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND storage is attached
         self.harness.add_storage("content-from-git", attach=True)
 
-        self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("git-sync")
 
         # without the try-finally, if any assertion fails, then hypothesis would reenter without
@@ -93,11 +93,11 @@ class TestReinitializeCalledOnce(unittest.TestCase):
 
         # GIVEN the current unit is a leader unit
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND storage is attached
         self.harness.add_storage("content-from-git", attach=True)
 
-        self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("git-sync")
 
         # without the try-finally, if any assertion fails, then hypothesis would reenter without
@@ -154,11 +154,11 @@ class TestReinitializeCalledOnce(unittest.TestCase):
 
         # GIVEN the current unit is a leader unit
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND storage is attached
         self.harness.add_storage("content-from-git", attach=True)
 
-        self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("git-sync")
 
         # without the try-finally, if any assertion fails, then hypothesis would reenter without
@@ -237,11 +237,11 @@ class TestConfigChanged(unittest.TestCase):
         try:
             # GIVEN the current unit is a leader unit
             self.harness.set_leader(True)
+            self.harness.begin_with_initial_hooks()
 
             # AND storage is attached
             self.harness.add_storage("content-from-git", attach=True)
 
-            self.harness.begin_with_initial_hooks()
             self.harness.container_pebble_ready("git-sync")
 
             # AND some initial config is provided

--- a/tests/unit/charm/test_status_vs_config.py
+++ b/tests/unit/charm/test_status_vs_config.py
@@ -11,12 +11,11 @@ from unittest.mock import patch
 
 import hypothesis.strategies as st
 import ops
+from charm import COSConfigCharm
 from helpers import FakeProcessVersionCheck
 from hypothesis import given
 from ops.model import ActiveStatus, BlockedStatus, Container
 from ops.testing import Harness
-
-from charm import COSConfigCharm
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/charm/test_status_vs_config.py
+++ b/tests/unit/charm/test_status_vs_config.py
@@ -50,11 +50,11 @@ class TestBlockedStatus(unittest.TestCase):
 
             # AND the current unit could be either a leader or not
             self.harness.set_leader(is_leader)
+            self.harness.begin_with_initial_hooks()
 
             # AND storage is attached
             self.harness.add_storage("content-from-git", attach=True)
 
-            self.harness.begin_with_initial_hooks()
             self.harness.container_pebble_ready("git-sync")
 
             # WHEN no config is provided
@@ -110,12 +110,12 @@ class TestRandomHooks(unittest.TestCase):
 
         # GIVEN app starts with a single unit (which is the leader)
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND storage is attached
         self.harness.add_storage("content-from-git", attach=True)
 
         # AND the usual startup hooks fire
-        self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("git-sync")
 
         try:
@@ -197,6 +197,7 @@ class TestStatusVsConfig(unittest.TestCase):
 
             # AND the current unit could be either a leader or not
             self.harness.set_leader(is_leader)
+            self.harness.begin_with_initial_hooks()
 
             # WHEN the repo URL is set
             self.harness.update_config({"git_repo": "http://does.not.really.matter/repo.git"})
@@ -230,6 +231,7 @@ class TestStatusVsConfig(unittest.TestCase):
 
             # AND the current unit is a leader (otherwise won't be able to update app data)
             self.harness.set_leader(True)
+            self.harness.begin_with_initial_hooks()
 
             # WHEN the repo URL is set
             self.harness.update_config({"git_repo": "http://does.not.really.matter/repo.git"})

--- a/tests/unit/charm/test_workload_version.py
+++ b/tests/unit/charm/test_workload_version.py
@@ -21,9 +21,9 @@ class TestWorkloadVersion(unittest.TestCase):
     @patch.object(Container, "exec", new=FakeProcessVersionCheck)
     def setUp(self):
         self.harness = Harness(COSConfigCharm)
+        self.harness.begin_with_initial_hooks()
         self.addCleanup(self.harness.cleanup)
         self.harness.add_storage("content-from-git", attach=True)
-        self.harness.begin_with_initial_hooks()
         self.harness.container_pebble_ready("git-sync")
 
     def test_workload_version_is_set(self):

--- a/tests/unit/charm/test_workload_version.py
+++ b/tests/unit/charm/test_workload_version.py
@@ -6,11 +6,10 @@ import unittest
 from unittest.mock import patch
 
 import ops
+from charm import COSConfigCharm
 from helpers import FakeProcessVersionCheck
 from ops.model import Container
 from ops.testing import Harness
-
-from charm import COSConfigCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tests/unit/prometheus-config/test_app_relation_data.py
+++ b/tests/unit/prometheus-config/test_app_relation_data.py
@@ -71,6 +71,7 @@ class TestAppRelationData(unittest.TestCase):
         """Scenario: Alert rules show up show up on disk only after config_changed etc. fired."""
         # GIVEN the current unit is the leader
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND prometheus-config relation formed
         rel_id = self.harness.add_relation("prometheus-config", "prom")
@@ -102,6 +103,7 @@ class TestAppRelationData(unittest.TestCase):
         """Scenario: Files are on disk and the charm is blocked, but now a relation joins."""
         # GIVEN the current unit is the leader
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND the user configures the repo url
         self.harness.update_config({"git_repo": "http://does.not.really.matter/repo.git"})
@@ -127,6 +129,7 @@ class TestAppRelationData(unittest.TestCase):
         """Scenario: A relation joins first, and only then the repo url is set."""
         # GIVEN the current unit is the leader
         self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
 
         # AND a relation joins
         for rel_name in [

--- a/tests/unit/prometheus-config/test_app_relation_data.py
+++ b/tests/unit/prometheus-config/test_app_relation_data.py
@@ -9,11 +9,10 @@ from unittest.mock import patch
 
 import ops
 import yaml
+from charm import COSConfigCharm
 from helpers import FakeProcessVersionCheck
 from ops.model import ActiveStatus, Container
 from ops.testing import Harness
-
-from charm import COSConfigCharm
 
 logger = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,28 +32,20 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,unit,integration}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being one new rule being ignored (which weren't check before anyway):
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.