### PR TITLE
fix cloning private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ to the following operators:
 Internally, the charm is using [`git-sync`][Git sync] to sync a remote repo with the local copy.
 The repo syncs on `update-status` or when the user manually runs the `sync-now` action.
 
+It's possible to sync a private repository by setting the `git_ssh_key` in the Juju configuration for the charm; please note that the key **will be saved in the model**, thus you should use a key with a very limited scope.
+
 ## Getting started
 
 ### Deployment
@@ -31,6 +33,8 @@ juju deploy cos-configuration-k8s \
   --config git_branch=main \
   --config git_depth=1 \
   --config prometheus_alert_rules_path=rules/prod/prometheus/
+# ... and additionally, for a private repo
+  --config git_ssh_key=@path/to/ssh/private.key
 
 juju relate cos-configuration-k8s prometheus-k8s
 ```

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 31
+LIBPATCH = 32
 
 logger = logging.getLogger(__name__)
 
@@ -525,7 +525,7 @@ def _validate_relation_by_interface_and_direction(
     relation = charm.meta.relations[relation_name]
 
     actual_relation_interface = relation.interface_name
-    if actual_relation_interface != expected_relation_interface:
+    if actual_relation_interface and actual_relation_interface != expected_relation_interface:
         raise RelationInterfaceMismatchError(
             relation_name, expected_relation_interface, actual_relation_interface
         )

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -67,21 +67,20 @@ and three optional arguments.
           def __init__(self, *args):
               super().__init__(*args)
               ...
-              self._loki_ready()
+              external_url = urlparse(self._external_url)
+              self.loki_provider = LokiPushApiProvider(
+                  self,
+                  address=external_url.hostname or self.hostname,
+                  port=external_url.port or 80,
+                  scheme=external_url.scheme,
+                  path=f"{external_url.path}/loki/api/v1/push",
+              )
               ...
 
-          def _loki_ready(self):
-              try:
-                  version = self._loki_server.version
-                  self.loki_provider = LokiPushApiProvider(self)
-                  logger.debug("Loki Provider is available. Loki version: %s", version)
-              except LokiServerNotReadyError as e:
-                  self.unit.status = MaintenanceStatus(str(e))
-              except LokiServerError as e:
-                  self.unit.status = BlockedStatus(str(e))
-
-  - `port`: Loki Push Api endpoint port. Default value: 3100.
-  - `rules_dir`: Directory to store alert rules. Default value: "/loki/rules".
+  - `port`: Loki Push Api endpoint port. Default value: `3100`.
+  - `scheme`: Loki Push Api endpoint scheme (`HTTP` or `HTTPS`). Default value: `HTTP`
+  - `address`: Loki Push Api endpoint address. Default value: `localhost`
+  - `path`: Loki Push Api endpoint path. Default value: `loki/api/v1/push`
 
 
 The `LokiPushApiProvider` object has several responsibilities:
@@ -481,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -370,7 +370,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 37
+LIBPATCH = 38
 
 logger = logging.getLogger(__name__)
 
@@ -602,15 +602,22 @@ class PrometheusConfig:
         # Create a mapping from paths to netlocs
         # Group alertmanager targets into a dictionary of lists:
         # {path: [netloc1, netloc2]}
-        paths = defaultdict(list)  # type: Dict[str, List[str]]
+        paths = defaultdict(list)  # type: Dict[Tuple[str, str], List[str]]
         for parsed in map(urlparse, sanitized):
             path = parsed.path or "/"
-            paths[path].append(parsed.netloc)
+            paths[(parsed.scheme, path)].append(parsed.netloc)
 
         return {
             "alertmanagers": [
-                {"path_prefix": path_prefix, "static_configs": [{"targets": netlocs}]}
-                for path_prefix, netlocs in paths.items()
+                {
+                    "scheme": scheme,
+                    "path_prefix": path_prefix,
+                    "static_configs": [{"targets": netlocs}],
+                    # FIXME figure out how to get alertmanager's ca_file into here
+                    #  Without this, prom errors: "x509: certificate signed by unknown authority"
+                    "tls_config": {"insecure_skip_verify": True},
+                }
+                for (scheme, path_prefix), netlocs in paths.items()
             ]
         }
 
@@ -1353,29 +1360,39 @@ class MetricsEndpointConsumer(Object):
         if not relation.units:
             return []
 
-        scrape_jobs = json.loads(relation.data[relation.app].get("scrape_jobs", "[]"))
+        scrape_configs = json.loads(relation.data[relation.app].get("scrape_jobs", "[]"))
 
-        if not scrape_jobs:
+        if not scrape_configs:
             return []
 
         scrape_metadata = json.loads(relation.data[relation.app].get("scrape_metadata", "{}"))
 
         if not scrape_metadata:
-            return scrape_jobs
+            return scrape_configs
 
         topology = JujuTopology.from_dict(scrape_metadata)
 
         job_name_prefix = "juju_{}_prometheus_scrape".format(topology.identifier)
-        scrape_jobs = PrometheusConfig.prefix_job_names(scrape_jobs, job_name_prefix)
-        scrape_jobs = PrometheusConfig.sanitize_scrape_configs(scrape_jobs)
+        scrape_configs = PrometheusConfig.prefix_job_names(scrape_configs, job_name_prefix)
+        scrape_configs = PrometheusConfig.sanitize_scrape_configs(scrape_configs)
 
         hosts = self._relation_hosts(relation)
 
-        scrape_jobs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
-            scrape_jobs, hosts, topology
+        scrape_configs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            scrape_configs, hosts, topology
         )
 
-        return scrape_jobs
+        # If scheme is https but no ca section present, then auto add "insecure_skip_verify",
+        # otherwise scraping errors out with "x509: certificate signed by unknown authority".
+        # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config
+        for scrape_config in scrape_configs:
+            tls_config = scrape_config.get("tls_config", {})
+            ca_present = "ca" in tls_config or "ca_file" in tls_config
+            if scrape_config.get("scheme") == "https" and not ca_present:
+                tls_config["insecure_skip_verify"] = True
+                scrape_config["tls_config"] = tls_config
+
+        return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:
         """Returns a mapping from unit names to (address, path) tuples, for the given relation."""
@@ -1793,10 +1810,10 @@ class MetricsEndpointProvider(Object):
            A list of dictionaries, where each dictionary specifies a
            single scrape job for Prometheus.
         """
-        jobs = self._jobs if self._jobs else [DEFAULT_JOB]
+        jobs = self._jobs or []
         if callable(self._lookaside_jobs):
-            return jobs + PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs())
-        return jobs
+            jobs.extend(PrometheusConfig.sanitize_scrape_configs(self._lookaside_jobs()))
+        return jobs or [DEFAULT_JOB]
 
     @property
     def _scrape_metadata(self) -> dict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -230,7 +230,7 @@ class COSConfigCharm(CharmBase):
         """
         return bool(self.config.get("git_repo"))
 
-    def _exec_sync_repo(self) -> Tuple[str, str]:
+    def _exec_sync_repo(self) -> Tuple[str, Optional[str]]:
         """Execute the sync command in the workload container.
 
         Raises:

--- a/src/charm.py
+++ b/src/charm.py
@@ -418,6 +418,9 @@ class COSConfigCharm(CharmBase):
     def _trust_ssh_remote(self):
         """Cleanup known_hosts and add the remote public SSH key."""
         repo = cast(str, self.config.get("git_repo"))
+        # Parse remotes in different forms, specifically:
+        # - git@<remote>:<user>/...
+        # - git+ssh://<user>@<remote>/...
         remote_regex = r"@(.+?)[:/]"
         matches: list = re.findall(remote_regex, repo)
         if matches:

--- a/src/charm.py
+++ b/src/charm.py
@@ -230,7 +230,7 @@ class COSConfigCharm(CharmBase):
         """
         return bool(self.config.get("git_repo"))
 
-    def _exec_sync_repo(self) -> Tuple[str, Optional[str]]:
+    def _exec_sync_repo(self) -> Tuple[str, str]:
         """Execute the sync command in the workload container.
 
         Raises:
@@ -256,7 +256,7 @@ class COSConfigCharm(CharmBase):
             for line in stderr.splitlines():
                 logger.info(f"git-sync: {line.strip()}")
 
-        return stdout, stderr
+        return stdout, stderr or ""
 
     def _remove_repo_folder(self):
         """Remove the repo folder."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -410,8 +410,9 @@ class COSConfigCharm(CharmBase):
     def _on_config_changed(self, _):
         """Event handler for ConfigChangedEvent."""
         if self.container.can_connect():
-            self._trust_ssh_remote()
-            self._save_ssh_key()
+            if self.config.get("git_ssh_key"):
+                self._trust_ssh_remote()
+                self._save_ssh_key()
         self._common_exit_hook()
 
     def _trust_ssh_remote(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,9 @@ class COSConfigCharm(CharmBase):
     def _save_ssh_key(self):
         """Save SSH key from config to a file."""
         ssh_key = self.config.get("git_ssh_key", "")
-        self.container.push(Path(self._ssh_key_file_name), ssh_key, make_dirs=True)
+        self.container.push(
+            Path(self._ssh_key_file_name), ssh_key, permissions=0o600, make_dirs=True
+        )
 
     @property
     def _git_sync_version(self) -> Optional[str]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,6 +415,8 @@ class COSConfigCharm(CharmBase):
     def _save_ssh_key(self):
         """Save SSH key from config to a file."""
         ssh_key = self.config.get("git_ssh_key", "")
+        # Key file must be readable by the user but not accessible by others.
+        # Ref: https://linux.die.net/man/1/ssh
         self.container.push(
             Path(self._ssh_key_file_name), ssh_key, permissions=0o600, make_dirs=True
         )


### PR DESCRIPTION
## Issue
Closes #66 


## Solution
The Key permission problem has been solved by simply changing the permissions of the private key file to `600`.

For the `known_hosts` problem, (file missing and manual trust prompt), the charm is now parsing the `git_repo` for the remote (e.g., `github.com`, `git.launchpad.net`) and automatically adding the remote's public key to `known_hosts` through `ssh-keyscan {remote}`.  
Note that this happens on **config-changed**, meaning that the charm will temporarily (until the first **config-changed**) fail the sync on `juju deploy`, but it's probably not an issue :)

I also updated the README to document the feature!