### PR TITLE
honor juju proxy settings when running git-sync

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -241,20 +241,11 @@ class COSConfigCharm(CharmBase):
             stdout, from the sync command.
             stderr, from the sync command.
         """
-        proxy_settings = {}
-        proxy_settings.update(
-            {
-                "https_proxy": os.environ["JUJU_CHARM_HTTPS_PROXY"]
-                if "JUJU_CHARM_HTTPS_PROXY" in os.environ
-                else "",
-                "http_proxy": os.environ["JUJU_CHARM_HTTP_PROXY"]
-                if "JUJU_CHARM_HTTP_PROXY" in os.environ
-                else "",
-                "no_proxy": os.environ["JUJU_CHARM_NO_PROXY"]
-                if "JUJU_CHARM_NO_PROXY" in os.environ
-                else "",
-            }
-        )
+        proxy_settings = {
+            "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+            "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+            "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+        }
         try:
             process = self.container.exec(
                 self._git_sync_command_line(), environment=proxy_settings

--- a/src/charm.py
+++ b/src/charm.py
@@ -241,8 +241,22 @@ class COSConfigCharm(CharmBase):
             stdout, from the sync command.
             stderr, from the sync command.
         """
+        proxy_settings = {}
+        proxy_settings.update(
+            {
+                "https_proxy": os.environ["JUJU_CHARM_HTTPS_PROXY"]
+                if "JUJU_CHARM_HTTPS_PROXY" in os.environ
+                else "",
+                "http_proxy": os.environ["JUJU_CHARM_HTTP_PROXY"]
+                if "JUJU_CHARM_HTTP_PROXY" in os.environ
+                else "",
+                "no_proxy": os.environ["JUJU_CHARM_NO_PROXY"]
+                if "JUJU_CHARM_NO_PROXY" in os.environ
+                else "",
+            }
+        )
         try:
-            process = self.container.exec(self._git_sync_command_line())
+            process = self.container.exec(self._git_sync_command_line(), environment=proxy_settings)
         except APIError as e:
             raise SyncError(str(e)) from e
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -256,7 +256,9 @@ class COSConfigCharm(CharmBase):
             }
         )
         try:
-            process = self.container.exec(self._git_sync_command_line(), environment=proxy_settings)
+            process = self.container.exec(
+                self._git_sync_command_line(), environment=proxy_settings
+            )
         except APIError as e:
             raise SyncError(str(e)) from e
 


### PR DESCRIPTION
## Issue
Closes #71.


## Solution
The charm should honor the Juju proxy settings when executing `git-sync`.

Juju lets you set some proxy configuration which ends up in the environment variables named `JUJU_CHARM_HTTP_PROXY`, `JUJU_CHARM_HTTPS_PROXY`, and `JUJU_CHARM_NO_PROXY`.

However, the charms don't automatically honor this configuration; instead, they require to set some other environment variables for the proxy configuration to take effect, namely `http_proxy`, `https_proxy`, and `no_proxy`. It's up to each individual charm to honor the Juju proxy settings or not.

This PR makes the change for the git-sync command :)