### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -143,14 +143,18 @@ class COSConfigCharm(CharmBase):
         self.prom_rules_provider = PrometheusRulesProvider(
             self,
             self.prometheus_relation_name,
-            dir_path=os.path.join(self._repo_path, cast(str, self.config["prometheus_alert_rules_path"])),
+            dir_path=os.path.join(
+                self._repo_path, cast(str, self.config["prometheus_alert_rules_path"])
+            ),
             recursive=True,
         )
 
         self.loki_rules_provider = LokiPushApiConsumer(
             self,
             self.loki_relation_name,
-            alert_rules_path=os.path.join(self._repo_path, cast(str, self.config["loki_alert_rules_path"])),
+            alert_rules_path=os.path.join(
+                self._repo_path, cast(str, self.config["loki_alert_rules_path"])
+            ),
             recursive=True,
             skip_alert_topology_labeling=True,
         )
@@ -158,7 +162,9 @@ class COSConfigCharm(CharmBase):
         self.grafana_dashboards_provider = GrafanaDashboardProvider(
             self,
             self.grafana_relation_name,
-            dashboards_path=os.path.join(self._repo_path, cast(str, self.config["grafana_dashboards_path"])),
+            dashboards_path=os.path.join(
+                self._repo_path, cast(str, self.config["grafana_dashboards_path"])
+            ),
         )
 
         self.service_patcher = KubernetesServicePatch(

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,14 +143,14 @@ class COSConfigCharm(CharmBase):
         self.prom_rules_provider = PrometheusRulesProvider(
             self,
             self.prometheus_relation_name,
-            dir_path=os.path.join(self._repo_path, self.config["prometheus_alert_rules_path"]),
+            dir_path=os.path.join(self._repo_path, cast(str, self.config["prometheus_alert_rules_path"])),
             recursive=True,
         )
 
         self.loki_rules_provider = LokiPushApiConsumer(
             self,
             self.loki_relation_name,
-            alert_rules_path=os.path.join(self._repo_path, self.config["loki_alert_rules_path"]),
+            alert_rules_path=os.path.join(self._repo_path, cast(str, self.config["loki_alert_rules_path"])),
             recursive=True,
             skip_alert_topology_labeling=True,
         )
@@ -158,7 +158,7 @@ class COSConfigCharm(CharmBase):
         self.grafana_dashboards_provider = GrafanaDashboardProvider(
             self,
             self.grafana_relation_name,
-            dashboards_path=os.path.join(self._repo_path, self.config["grafana_dashboards_path"]),
+            dashboards_path=os.path.join(self._repo_path, cast(str, self.config["grafana_dashboards_path"])),
         )
 
         self.service_patcher = KubernetesServicePatch(
@@ -456,7 +456,7 @@ class COSConfigCharm(CharmBase):
 
     def _save_ssh_key(self):
         """Save SSH key from config to a file."""
-        ssh_key = self.config.get("git_ssh_key", "")
+        ssh_key = cast(str, self.config.get("git_ssh_key", ""))
         # Key file must be readable by the user but not accessible by others.
         # Ref: https://linux.die.net/man/1/ssh
         self.container.push(


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with / without this change, with ops 2.12 and ops 2.13 (or the PR linked above if before that release).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A