### PR TITLE
Reschedule the update-libs workflow

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   # Check regularly the upstream every four hours
   schedule:
-    - cron: "0 0,4,8,12,16,20 * * *"
+    - cron: "30 12 * * *"
 
 jobs:
   update-lib:


### PR DESCRIPTION
## Issue
An "(Unknown event)" is being triggered by an "(Unnamed workflow)".
https://github.com/canonical/cos-configuration-k8s-operator/actions

This happens every 4 hours as a shadow of another workflow:
https://github.com/canonical/cos-configuration-k8s-operator/actions/workflows/update-libs.yaml

This happens because the last person to "schedule" was @rbarry82 and is no longer part of the org.

> When the last user to commit to the cron schedule of a workflow is removed from the organization, the scheduled workflow will be disabled. If a user with write permissions to the repository makes a commit that changes the cron schedule, the scheduled workflow will be re-activated. ([ref](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/events-that-trigger-workflows#schedule))

## Solution
Reschedule the workflow by an "actor" that is part of the org. "Rescheduling" means changing the `cron` directive.

- For update-libs, once a day is enough.
- Setting to 30-past hour because:

> High load times include the start of every hour. If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour.