### PR TITLE
fix: use set_ports instead of open_port

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-ops < 2.5
+ops
 PyYAML
 lightkube
 lightkube-models

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,7 +95,7 @@ class COSConfigCharm(CharmBase):
         self._tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])
 
         self.container = self.unit.get_container(self._container_name)
-        self.unit.open_port(protocol="tcp", port=self._git_sync_port)
+        self.unit.open_port(self._git_sync_port)
 
         # Core lifecycle events
         self.framework.observe(self.on.config_changed, self._on_config_changed)

--- a/src/charm.py
+++ b/src/charm.py
@@ -95,7 +95,7 @@ class COSConfigCharm(CharmBase):
         self._tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])
 
         self.container = self.unit.get_container(self._container_name)
-        self.unit.open_port(self._git_sync_port)
+        self.unit.set_ports(self._git_sync_port)
 
         # Core lifecycle events
         self.framework.observe(self.on.config_changed, self._on_config_changed)


### PR DESCRIPTION
## Issue

`open_port` doesn't close ports; if the port changes on upgrades, the previous one isn't closed.

## Solution

Use `set_ports` instead, as documented [here](https://github.com/canonical/operator/blob/ab239e1156bd206f9825b5be96fbf83121489fee/ops/model.py#L699).