### PR TITLE
Gracefully handle charm initialization when storage not attached

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from charms.tempo_k8s.v1.charm_tracing import trace_charm
 from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer
 from ops.charm import ActionEvent, CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, ModelError
 from ops.pebble import APIError, ChangeError, ExecError
 
 logger = logging.getLogger(__name__)
@@ -90,6 +90,12 @@ class COSConfigCharm(CharmBase):
             # Storage isn't available yet. Since storage becomes available early enough, no need
             # to observe storage-attached and complicate things; simply abort until it is ready.
             return
+        try:
+            self._git_sync_mount_point = self.model.storages["content-from-git"][0].location
+        except ModelError:
+            # Storage isn't available yet.
+            return
+
         self._git_sync_mount_point = self.model.storages["content-from-git"][0].location
         self._repo_path = os.path.join(self._git_sync_mount_point, self.SUBDIR)
         self._tracing = TracingEndpointRequirer(self, protocols=["otlp_http"])


### PR DESCRIPTION
## Issue
https://github.com/canonical/cos-configuration-k8s-operator/issues/84


## Solution
When the charm is initialized, we try to access the storage, and if it is not yet available, return gracefully.

## Context
This was faced during deploying cos-configuration-k8s in a bundle, where tests would fail if charm hooks were fired before storage was attached. 

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
