### PR TITLE
feat: send alerts over remote write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__/
 *.py[cod]
 .tox/
 .hypothesis/
+
+.charm_tracing_buffer.raw

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -66,6 +66,11 @@ requires:
       Tracing endpoint for integrating with tempo.
     limit: 1
     interface: tracing
+  send-remote-write:
+    interface: prometheus_remote_write
+    optional: true
+    description: |
+      Send alert rules via Prometheus remote write.
 
 peers:
   replicas:

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,6 +70,7 @@ class COSConfigCharm(CharmBase):
     SUBDIR: Final = "repo"
 
     prometheus_relation_name = "prometheus-config"
+    prometheus_rw_relation_name = "send-remote-write"
     loki_relation_name = "loki-config"
     grafana_relation_name = "grafana-dashboards"
 
@@ -152,6 +153,12 @@ class COSConfigCharm(CharmBase):
         self.prom_rules_provider = PrometheusRulesProvider(
             self,
             self.prometheus_relation_name,
+            dir_path=os.path.join(self._repo_path, prometheus_alert_rules_path),
+            recursive=True,
+        )
+        self.remote_write_rules_provider = PrometheusRulesProvider(
+            self,
+            self.prometheus_rw_relation_name,
             dir_path=os.path.join(self._repo_path, prometheus_alert_rules_path),
             recursive=True,
         )
@@ -400,6 +407,7 @@ class COSConfigCharm(CharmBase):
                 type(current_hash),
             )
             self.prom_rules_provider._reinitialize_alert_rules()
+            self.remote_write_rules_provider._reinitialize_alert_rules()
             self.loki_rules_provider._reinitialize_alert_rules()
             self.grafana_dashboards_provider._reinitialize_dashboard_data(inject_dropdowns=False)
             self._stored_set("reinit_without_topology_dropdowns", "Done")

--- a/tests/unit/charm/test_reinitialize.py
+++ b/tests/unit/charm/test_reinitialize.py
@@ -130,7 +130,7 @@ class TestReinitializeCalledOnce(unittest.TestCase):
             self.harness.charm.on.update_status.emit()
 
             # THEN reinitialization takes place only once
-            self.assertEqual(self.prom_mock.call_count, 1)
+            self.assertEqual(self.prom_mock.call_count, 2)
             self.assertEqual(self.loki_mock.call_count, 1)
             self.assertEqual(self.graf_mock.call_count, 1)
 
@@ -186,7 +186,7 @@ class TestReinitializeCalledOnce(unittest.TestCase):
             self.harness.charm.on.update_status.emit()
 
             # THEN reinitialization occurred only once more since repo was unset
-            self.assertEqual(self.prom_mock.call_count, 1)
+            self.assertEqual(self.prom_mock.call_count, 2)
             self.assertEqual(self.loki_mock.call_count, 1)
             self.assertEqual(self.graf_mock.call_count, 1)
 


### PR DESCRIPTION
## Issue
Currently, `cos-config` only sends alerts over `prometheus_scrape`. However, this means it can't send alerts directly to Mimir (as it doesn't have that relation). Using `grafana-agent` or `opentelemetry-collector` as an intermediary adds their topology to the alert, which obviously doesn't work.


## Solution
Add a `PrometheusRuleProvider` instance to send rules over a newly-added `prometheus_remote_write` relation.

