### PR TITLE
Update git-sync image to version v3.6.9

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -41,7 +41,7 @@ resources:
   git-sync-image:
     type: oci-image
     description: OCI image for git-sync
-    upstream-source: k8s.gcr.io/git-sync/git-sync@sha256:d16f5b2bca94cdbb4e40b256bfe639450a6f0577dbd8b3fcaf126a2261822fcd  # renovate: oci-image tag: v3.5.0
+    upstream-source: k8s.gcr.io/git-sync/git-sync:v3.6.9
 
 storage:
   content-from-git:


### PR DESCRIPTION
## Issue
Currently the upstream-source is set to version 3.5.0. Notable upstream [fixes since that version](https://github.com/kubernetes/git-sync/compare/v3.5.0...v3.6.9) in 3.x:
- Bump golang to address vulns.
- Prom client CVE.
- Base-image CVEs.
- Various bug fixes.


## Solution
Bump upstream-source to 3.6.9.
