### PR TITLE
fix: use proxy when cloning if proxy model config set

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -211,7 +211,6 @@ class COSConfigCharm(CharmBase):
             self._update_hash_and_rel_data()
             return
 
-        # TODO: add logic from _on_config_changed here
         if self.config.get("git_ssh_key") or self.config.get("git_ssh_key_secret"):
             self._trust_ssh_remote()
             if not self._push_ssh_config():


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #119.

## Solution
<!-- A summary of the solution addressing the above issue -->
When we have a proxy set through Juju's model config and we have either an SSH key or an SSH secret key, we should have an SSH config file at `/root/.ssh/config` with permissions 600 that looks something like:
```
ProxyCommand socat - "PROXY:10.181.160.178:%h:%p,proxyport=3128"
```

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
First, install Squid on your VM and configure it to be your proxy.
Here’s a short, clean Markdown instruction block you can use:

---

###  Install Squid

```bash
sudo apt update
sudo apt install -y squid
```
Edit the Squid config file:

```bash
sudo nano /etc/squid/squid.conf
```

Ensure the following block exists:
```conf
acl SSL_ports port 443
acl SSL_ports port 22
acl Safe_ports port 80          # http
acl Safe_ports port 21          # ftp
acl Safe_ports port 443         # https
acl Safe_ports port 70          # gopher
acl Safe_ports port 210         # wais
acl Safe_ports port 1025-65535  # unregistered ports
acl Safe_ports port 280         # http-mgmt
acl Safe_ports port 488         # gss-http
acl Safe_ports port 591         # filemaker
acl Safe_ports port 777         # multiling http
acl Safe_ports port 22
acl CONNECT method CONNECT
acl jujuclients src 10.1.0.0/16
http_access allow jujuclients

```

---

### Restart Squid

```bash
sudo systemctl restart squid
```

Enable it on boot (optional):

```bash
sudo systemctl enable squid
```

---

### Open Firewall (if needed)

```bash
sudo ufw allow 3128/tcp
```

---

### Set your Juju model config for the HTTP and HTTPS proxies

```bash
juju model-config juju-https-proxy=http://10.181.160.178:3128
juju model-config juju-http-proxy=http://10.181.160.178:3128
```
---

### View Squid Access Logs
The access log file should be updated every time you make a request through the proxy. This will be helpful when testing that `git-sync` is actually going through the proxy.
```bash
sudo tail -f /var/log/squid/access.log
```

---

### Testing Scenarios
Now that you have Squid serving as your forward proxy, now we can test that `cos-config` goes through the proxy when a value is set. There are four scenarios we need to test. Pack the charm locally.
### HTTPS with no proxy
1. Ensure `juju model-config juju-https-proxy` is unset.
```bash
juju model-config juju-https-proxy=
```
2. Set the following
```bash
jc cos-config-two git_repo=https://github.com/sinapah/cos-config
jc cos-config-two git_branch=main
jc cos-config git_ssh_key_secret=secret://<your-secret-id>/key
```
3. Now, try to sync the repo.
```bash
juju run cos-config/0 sync-now
```
It should succeed and if you look at the Squid access logs, you should see **NO** recent entries.
### HTTPS with a proxy
1. Ensure `juju model-config juju-https-proxy` is unset.
```bash
juju model-config juju-https-proxy=http://10.181.160.178:3128
```
2. Set the following
```bash
jc cos-config-two git_repo=https://github.com/sinapah/cos-config
jc cos-config-two git_branch=main
jc cos-config git_ssh_key_secret=secret://<your-secret-id>/key
```
3. Now, try to sync the repo.
```bash
juju run cos-config/0 sync-now
```
It should succeed and if you look at the Squid access logs, you should see recent entries.
### SSH without a proxy
Before proceeding, ensure you have set the appropriate Juju model config.
```bash
juju model-config juju-https-proxy=
```
Now, you can continue.
1. Use SSH for cloning the repo.
```bash
jc cos-config git_repo=git@github.com:sinapah/cos-config.git
```
2. Add a secret for your SSH key as [described](https://github.com/canonical/cos-configuration-k8s-operator/blob/b500516b21b3c150c96a65102a00b3624615eefc/charmcraft.yaml#L105) in `charmcraft.yaml`.
3. Set the `git_ssh_key_secret` config option. Ensure you have granted the secret to the charm.
```bash
jc cos-config git_ssh_key_secret=secret://<your-secret-id>/key
```
4. Now, try to sync the repo.
```bash
juju run cos-config/0 sync-now
```
It should succeed and if you look at the Squid access logs, you should NOT see recent entries.
```bash
sudo tail -f /var/log/squid/access.log
```
5. There should also be no file inside the `git-sync` container with the path `/root/.ssh/config`.
### SSH with a proxy
Before proceeding, ensure you have set the appropriate Juju model config.
```bash
juju model-config juju-https-proxy=http://10.181.160.178:3128
```
Now, you can continue.
1. Use SSH for cloning the repo.
```bash
jc cos-config git_repo=git@github.com:sinapah/cos-config.git
```
2. Add a secret for your SSH key as [described](https://github.com/canonical/cos-configuration-k8s-operator/blob/b500516b21b3c150c96a65102a00b3624615eefc/charmcraft.yaml#L105) in `charmcraft.yaml`.
3. Set the `git_ssh_key_secret` config option. Ensure you have granted the secret to the charm.
```bash
jc cos-config git_ssh_key_secret=secret://<your-secret-id>/key
```
4. Now, try to sync the repo.
```bash
juju run cos-config/0 sync-now
```
It should succeed and if you look at the Squid access logs, you should see  recent entries.
```bash
sudo tail -f /var/log/squid/access.log
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
